### PR TITLE
Fix formatting of JSON SPDX documents in Example 7

### DIFF
--- a/example7/spdx/example7-bin.spdx.json
+++ b/example7/spdx/example7-bin.spdx.json
@@ -1,41 +1,48 @@
-{"spdxVersion": "SPDX-2.2",
-	"dataLicense": "CC0-1.0",
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {
+  "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
-    "creators": [{
-			"Person": "Nisha K (nishak@vmware.com)"
-		}]
-	},
+    "creators": [
+      {
+        "Person": "Nisha K (nishak@vmware.com)"
+      }
+    ]
+  },
   "name": "hello-go-binary.spdx.json",
   "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-go-binary",
-	"externalDocumentRefs": [
-		{
-			"externalDocumentId": "DocumentRef-hello-go-module",
-			"checksum": {
-				"algorithm": "SHA1",
-				"checksumValue": "d661f8f831a99c288a64e5843b4794ad5181224a"
-			},
-			"spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-go-module-cfa0c58d-79db-4860-99b6-258477e4838b"
-		},
-		{
-			"externalDocumentId": "DocumentRef-golang-dist",
-			"checksum": {
-				"algorithm": "SHA1",
-				"checksumValue": "b6cf54a46329e7cc7610aa5d244018b80103d111"
-			},
-			"spdxDocument": "https://swinslow.net/spdx-examples/example7/golang-dist-492dfde4-318b-49f7-b48c-934bfafbde48"
-		},
-		{
-			"externalDocumentId": "DocumentRef-hello-imports",
-			"checksum": {
-				"algorithm": "SHA1",
-				"checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c"
-			},
-			"spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-imports-c2d068df-67aa-4c68-98c8-100b450fc408"
-		}],
-	"documentDescribes": ["SPDXRef-go-bin-hello"],
-	"packages": [{
+  "externalDocumentRefs": [
+    {
+      "externalDocumentId": "DocumentRef-hello-go-module",
+      "checksum": {
+        "algorithm": "SHA1",
+        "checksumValue": "d661f8f831a99c288a64e5843b4794ad5181224a"
+      },
+      "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-go-module-cfa0c58d-79db-4860-99b6-258477e4838b"
+    },
+    {
+      "externalDocumentId": "DocumentRef-golang-dist",
+      "checksum": {
+        "algorithm": "SHA1",
+        "checksumValue": "b6cf54a46329e7cc7610aa5d244018b80103d111"
+      },
+      "spdxDocument": "https://swinslow.net/spdx-examples/example7/golang-dist-492dfde4-318b-49f7-b48c-934bfafbde48"
+    },
+    {
+      "externalDocumentId": "DocumentRef-hello-imports",
+      "checksum": {
+        "algorithm": "SHA1",
+        "checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c"
+      },
+      "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-imports-c2d068df-67aa-4c68-98c8-100b450fc408"
+    }
+  ],
+  "documentDescribes": [
+    "SPDXRef-go-bin-hello"
+  ],
+  "packages": [
+    {
       "packageName": "hello",
       "SPDXID": "SPDXRef-go-bin-hello",
       "downloadLocation": "git@github.com:swinslow/spdx-examples.git#example7/content/build/hello",
@@ -43,22 +50,23 @@
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-		}],
-	"relationships": [
-		{
-			"spdxElementId": "DocumentRef-golang-dist",
-			"relatedSpdxElement": "DocumentRef-hello-go-module",
-			"relationshipType": "BUILD_TOOL_OF"
-		},
-		{
-			"spdxElementId": "DocumentRef-golang-dist:SPDXRef-go-compiler",
-			"relatedSpdxElement": "SPDXRef-go-bin-hello",
-			"relationshipType": "GENERATES"
-		},
-		{
-			"spdxElementId": "DocumentRef-hello-imports",
-			"relatedSpdxElement": "SPDXRef-go-bin-hello",
-			"relationshipType": "STATIC_LINK"
-		}
-	]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "DocumentRef-golang-dist",
+      "relatedSpdxElement": "DocumentRef-hello-go-module",
+      "relationshipType": "BUILD_TOOL_OF"
+    },
+    {
+      "spdxElementId": "DocumentRef-golang-dist:SPDXRef-go-compiler",
+      "relatedSpdxElement": "SPDXRef-go-bin-hello",
+      "relationshipType": "GENERATES"
+    },
+    {
+      "spdxElementId": "DocumentRef-hello-imports",
+      "relatedSpdxElement": "SPDXRef-go-bin-hello",
+      "relationshipType": "STATIC_LINK"
+    }
+  ]
 }

--- a/example7/spdx/example7-go-module.spdx.json
+++ b/example7/spdx/example7-go-module.spdx.json
@@ -1,16 +1,22 @@
-{"spdxVersion": "SPDX-2.2",
-	"dataLicense": "CC0-1.0",
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {
+  "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
-    "creators": [{
-			"Person": "Nisha K (nishak@vmware.com)"
-		}]
-	},
+    "creators": [
+      {
+        "Person": "Nisha K (nishak@vmware.com)"
+      }
+    ]
+  },
   "name": "hello-go-module.spdx.json",
   "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-go-module",
-	"documentDescribes": ["SPDXRef-go-module-example.com/hello"],
-	"packages": [{
+  "documentDescribes": [
+    "SPDXRef-go-module-example.com/hello"
+  ],
+  "packages": [
+    {
       "packageName": "example.com/hello",
       "SPDXID": "SPDXRef-go-module-example.com/hello",
       "downloadLocation": "git@github.com:swinslow/spdx-examples.git#example7/content/src/hello",
@@ -18,5 +24,6 @@
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-		}]
+    }
+  ]
 }

--- a/example7/spdx/example7-golang.spdx.json
+++ b/example7/spdx/example7-golang.spdx.json
@@ -1,37 +1,46 @@
-{"spdxVersion": "SPDX-2.2",
-	"dataLicense": "CC0-1.0",
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {
+  "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
-    "creators": [{
-			"Person": "Nisha K (nishak@vmware.com)"
-		}]
-	},
+    "creators": [
+      {
+        "Person": "Nisha K (nishak@vmware.com)"
+      }
+    ]
+  },
   "name": "golang-dist",
   "documentNamespace": "https://swinslow.net/spdx-examples/example7/golang-dist",
-	"documentDescribes": ["SPDXRef-golang-dist"],
-	"packages": [{
+  "documentDescribes": [
+    "SPDXRef-golang-dist"
+  ],
+  "packages": [
+    {
       "packageName": "go1.16.4.linux-amd64",
       "SPDXID": "SPDXRef-golang-dist",
       "downloadLocation": "https://golang.org/dl/go1.16.4.linux-amd64.tar.gz",
-			"packageVersion": "1.16.4",
+      "packageVersion": "1.16.4",
       "filesAnalyzed": "false",
-			"checksums": [{
-				"algorithm": "SHA256",
-				"checksumValue": "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
-			}],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
+        }
+      ],
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "LicenseRef-Golang-BSD-plus-Patents",
       "packageCopyrightText": "Copyright (c) 2009 The Go Authors. All rights reserved."
-		},
-	  {
+    },
+    {
       "packageName": "go",
       "SPDXID": "SPDXRef-go-compiler",
       "downloadLocation": "https://golang.org/dl/go1.16.4.linux-amd64.tar.gz",
-			"packageVersion": "1.16.4",
+      "packageVersion": "1.16.4",
       "filesAnalyzed": "false",
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-	  }]
+    }
+  ]
 }

--- a/example7/spdx/example7-third-party-modules.spdx.json
+++ b/example7/spdx/example7-third-party-modules.spdx.json
@@ -1,19 +1,24 @@
-{"spdxVersion": "SPDX-2.2",
-	"dataLicense": "CC0-1.0",
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {
+  "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
-    "creators": [{
-			"Person": "Nisha K (nishak@vmware.com)"
-		}]
-	},
+    "creators": [
+      {
+        "Person": "Nisha K (nishak@vmware.com)"
+      }
+    ]
+  },
   "name": "hello-imports.spdx.json",
   "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-imports",
-	"documentDescribes": [
-		"SPDXRef-go-module-golang.org/x/text",
-		"SPDXRef-go-module-rsc.io/quote",
-		"SPDXRef-go-module-rsc.io/sampler"],
-	"packages": [{
+  "documentDescribes": [
+    "SPDXRef-go-module-golang.org/x/text",
+    "SPDXRef-go-module-rsc.io/quote",
+    "SPDXRef-go-module-rsc.io/sampler"
+  ],
+  "packages": [
+    {
       "packageName": "golang.org/x/text",
       "SPDXID": "SPDXRef-go-module-golang.org/x/text",
       "downloadLocation": "go://golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c",
@@ -21,8 +26,8 @@
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-		},
-		{
+    },
+    {
       "packageName": "rsc.io/quote",
       "SPDXID": "SPDXRef-go-module-rsc.io/quote",
       "downloadLocation": "go://rsc.io/quote@v1.5.2",
@@ -30,8 +35,8 @@
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-		},
-		{
+    },
+    {
       "packageName": "rsc.io/sampler",
       "SPDXID": "SPDXRef-go-module-rsc.io/sampler",
       "downloadLocation": "go://rsc.io/sampler@v1.3.0",
@@ -39,5 +44,6 @@
       "packageLicenseConcluded": "NOASSERTION",
       "packageLicenseDeclared": "NOASSERTION",
       "packageCopyrightText": "NOASSERTION"
-		}]
+    }
+  ]
 }


### PR DESCRIPTION
The JSON files of Example 7 are indented inconsistently with tabs and spaces, causing the files to appear unaligned in some editors.

This pull request reformats these files with a consistent indentation level of two spaces.

Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>