### PR TITLE
Addressing #34, correcting namespace URIs, updating checksums

### DIFF
--- a/example7/spdx/example7-bin.spdx.json
+++ b/example7/spdx/example7-bin.spdx.json
@@ -5,9 +5,7 @@
   "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
     "creators": [
-      {
-        "Person": "Nisha K (nishak@vmware.com)"
-      }
+      "Person: Nisha K (nishak@vmware.com)"
     ]
   },
   "name": "hello-go-binary.spdx.json",
@@ -17,7 +15,7 @@
       "externalDocumentId": "DocumentRef-hello-go-module",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "d661f8f831a99c288a64e5843b4794ad5181224a"
+        "checksumValue": "11d7774ac38f40e009dcee453a760750aea75bbd"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-go-module-cfa0c58d-79db-4860-99b6-258477e4838b"
     },
@@ -25,7 +23,7 @@
       "externalDocumentId": "DocumentRef-golang-dist",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "b6cf54a46329e7cc7610aa5d244018b80103d111"
+        "checksumValue": "fd1a82d7affd688cca8896211ca1a3f177214323"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/golang-dist-492dfde4-318b-49f7-b48c-934bfafbde48"
     },
@@ -33,7 +31,7 @@
       "externalDocumentId": "DocumentRef-hello-imports",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "14ff98203c3ddd2bd4803c00b5225d2551ca603c"
+        "checksumValue": "c8a2beb3405bfe9eed0076b0e237ff59f6c4188f"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-imports-c2d068df-67aa-4c68-98c8-100b450fc408"
     }

--- a/example7/spdx/example7-go-module.spdx.json
+++ b/example7/spdx/example7-go-module.spdx.json
@@ -5,13 +5,11 @@
   "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
     "creators": [
-      {
-        "Person": "Nisha K (nishak@vmware.com)"
-      }
+      "Person: Nisha K (nishak@vmware.com)"
     ]
   },
   "name": "hello-go-module.spdx.json",
-  "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-go-module",
+  "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-go-module-cfa0c58d-79db-4860-99b6-258477e4838b",
   "documentDescribes": [
     "SPDXRef-go-module-example.com/hello"
   ],

--- a/example7/spdx/example7-golang.spdx.json
+++ b/example7/spdx/example7-golang.spdx.json
@@ -5,13 +5,11 @@
   "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
     "creators": [
-      {
-        "Person": "Nisha K (nishak@vmware.com)"
-      }
+      "Person: Nisha K (nishak@vmware.com)"
     ]
   },
   "name": "golang-dist",
-  "documentNamespace": "https://swinslow.net/spdx-examples/example7/golang-dist",
+  "documentNamespace": "https://swinslow.net/spdx-examples/example7/golang-dist-492dfde4-318b-49f7-b48c-934bfafbde48",
   "documentDescribes": [
     "SPDXRef-golang-dist"
   ],

--- a/example7/spdx/example7-third-party-modules.spdx.json
+++ b/example7/spdx/example7-third-party-modules.spdx.json
@@ -5,13 +5,11 @@
   "creationInfo": {
     "created": "2020-11-24T01:12:27Z",
     "creators": [
-      {
-        "Person": "Nisha K (nishak@vmware.com)"
-      }
+      "Person: Nisha K (nishak@vmware.com)"
     ]
   },
   "name": "hello-imports.spdx.json",
-  "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-imports",
+  "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-imports-c2d068df-67aa-4c68-98c8-100b450fc408",
   "documentDescribes": [
     "SPDXRef-go-module-golang.org/x/text",
     "SPDXRef-go-module-rsc.io/quote",


### PR DESCRIPTION
This is a proposed fix for #34.

While working on this adjustment, I noticed that the original SHA1 sums didn't agree with the existing JSON files (using the sha1sum utility from GNU coreutils 8.30).  I'm not certain @nishakm used the same method to generate the SHA1 sums, so please correct my sums if they don't agree with your outcome.  It's possible the sums were invalidated by the previous formatting change PR.

I also noticed that the namespace URIs in the referenced documents didn't include the GUID portion present in the references in `example7/spdx/example7-bin.spdx.json`.  This did not agree with my reading of 6.5.2, so my proposal adds the GUID to the namespaces of each document.

This PR attempts to address the above mentioned issues.
