### PR TITLE
fix example 7

### DIFF
--- a/example7/spdx/example7-bin.spdx.json
+++ b/example7/spdx/example7-bin.spdx.json
@@ -15,7 +15,7 @@
       "externalDocumentId": "DocumentRef-hello-go-module",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "11d7774ac38f40e009dcee453a760750aea75bbd"
+        "checksumValue": "0d81fd1366563fcd47c506fc26df47f5b63187c3"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-go-module-cfa0c58d-79db-4860-99b6-258477e4838b"
     },
@@ -23,7 +23,7 @@
       "externalDocumentId": "DocumentRef-golang-dist",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "fd1a82d7affd688cca8896211ca1a3f177214323"
+        "checksumValue": "05cad37dc3aff07b1852e3642f68de457b0806b5"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/golang-dist-492dfde4-318b-49f7-b48c-934bfafbde48"
     },
@@ -31,7 +31,7 @@
       "externalDocumentId": "DocumentRef-hello-imports",
       "checksum": {
         "algorithm": "SHA1",
-        "checksumValue": "c8a2beb3405bfe9eed0076b0e237ff59f6c4188f"
+        "checksumValue": "018ca697ea33f6e50b8056e2e8f11ae7197b11d3"
       },
       "spdxDocument": "https://swinslow.net/spdx-examples/example7/hello-imports-c2d068df-67aa-4c68-98c8-100b450fc408"
     }
@@ -41,19 +41,19 @@
   ],
   "packages": [
     {
-      "packageName": "hello",
+      "name": "hello",
       "SPDXID": "SPDXRef-go-bin-hello",
-      "downloadLocation": "git@github.com:swinslow/spdx-examples.git#example7/content/build/hello",
+      "downloadLocation": "git://git@github.com:swinslow/spdx-examples.git#example7/content/build/hello",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     }
   ],
   "relationships": [
     {
-      "spdxElementId": "DocumentRef-golang-dist",
-      "relatedSpdxElement": "DocumentRef-hello-go-module",
+      "spdxElementId": "DocumentRef-golang-dist:SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "DocumentRef-hello-go-module:SPDXRef-DOCUMENT",
       "relationshipType": "BUILD_TOOL_OF"
     },
     {
@@ -62,7 +62,7 @@
       "relationshipType": "GENERATES"
     },
     {
-      "spdxElementId": "DocumentRef-hello-imports",
+      "spdxElementId": "DocumentRef-hello-imports:SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-go-bin-hello",
       "relationshipType": "STATIC_LINK"
     }

--- a/example7/spdx/example7-go-module.spdx.json
+++ b/example7/spdx/example7-go-module.spdx.json
@@ -15,13 +15,13 @@
   ],
   "packages": [
     {
-      "packageName": "example.com/hello",
-      "SPDXID": "SPDXRef-go-module-example.com/hello",
-      "downloadLocation": "git@github.com:swinslow/spdx-examples.git#example7/content/src/hello",
+      "name": "example.com/hello",
+      "SPDXID": "SPDXRef-go-module-example.com-hello",
+      "downloadLocation": "git://git@github.com:swinslow/spdx-examples.git#example7/content/src/hello",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     }
   ]
 }

--- a/example7/spdx/example7-golang.spdx.json
+++ b/example7/spdx/example7-golang.spdx.json
@@ -15,10 +15,10 @@
   ],
   "packages": [
     {
-      "packageName": "go1.16.4.linux-amd64",
+      "name": "go1.16.4.linux-amd64",
       "SPDXID": "SPDXRef-golang-dist",
       "downloadLocation": "https://golang.org/dl/go1.16.4.linux-amd64.tar.gz",
-      "packageVersion": "1.16.4",
+      "version": "1.16.4",
       "filesAnalyzed": false,
       "checksums": [
         {
@@ -26,19 +26,19 @@
           "checksumValue": "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
         }
       ],
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "LicenseRef-Golang-BSD-plus-Patents",
-      "packageCopyrightText": "Copyright (c) 2009 The Go Authors. All rights reserved."
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "LicenseRef-Golang-BSD-plus-Patents",
+      "copyrightText": "Copyright (c) 2009 The Go Authors. All rights reserved."
     },
     {
-      "packageName": "go",
+      "name": "go",
       "SPDXID": "SPDXRef-go-compiler",
       "downloadLocation": "https://golang.org/dl/go1.16.4.linux-amd64.tar.gz",
-      "packageVersion": "1.16.4",
+      "version": "1.16.4",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     }
   ]
 }

--- a/example7/spdx/example7-third-party-modules.spdx.json
+++ b/example7/spdx/example7-third-party-modules.spdx.json
@@ -17,31 +17,31 @@
   ],
   "packages": [
     {
-      "packageName": "golang.org/x/text",
-      "SPDXID": "SPDXRef-go-module-golang.org/x/text",
-      "downloadLocation": "go://golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c",
+      "name": "golang.org/x/text",
+      "SPDXID": "SPDXRef-go-module-golang.org-x-text",
+      "downloadLocation": "git://golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     },
     {
-      "packageName": "rsc.io/quote",
-      "SPDXID": "SPDXRef-go-module-rsc.io/quote",
-      "downloadLocation": "go://rsc.io/quote@v1.5.2",
+      "name": "rsc.io/quote",
+      "SPDXID": "SPDXRef-go-module-rsc.io-quote",
+      "downloadLocation": "git://rsc.io/quote@v1.5.2",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     },
     {
-      "packageName": "rsc.io/sampler",
-      "SPDXID": "SPDXRef-go-module-rsc.io/sampler",
-      "downloadLocation": "go://rsc.io/sampler@v1.3.0",
+      "name": "rsc.io/sampler",
+      "SPDXID": "SPDXRef-go-module-rsc.io-sampler",
+      "downloadLocation": "git://rsc.io/sampler@v1.3.0",
       "filesAnalyzed": false,
-      "packageLicenseConcluded": "NOASSERTION",
-      "packageLicenseDeclared": "NOASSERTION",
-      "packageCopyrightText": "NOASSERTION"
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
     }
   ]
 }


### PR DESCRIPTION
Fix some example 7 spdx files:
  - Dont have `package` in json fields #45 
  - Invalid download locations #42 (I changed `go` to `git`, I think that what go uses under the covers so thought it would be fine)
  - Fix some other download locations #27 
  - Fix bad characters in SPDX Id (dont think `/` is allowed so changed them to `-`)
  - Added SPDX Id to relationships, the documentation says only the `DocumentRef` is optional. I assumed the document ids were the `SPDXRef-DOCUMENT` but that might not be correct