### PR TITLE
Fix typo of OSS-NA-2023 example dir name

### DIFF
--- a/presentations/README.md
+++ b/presentations/README.md
@@ -1,5 +1,9 @@
-# Examples form SPDX Presentations
+# Examples from SPDX Presentations
 
 This directory contains examples from the following presentations:
 
-* The OSSSumit2023 directory contains the SPDX JSON files used in the SBOM Primary presentation [An SBOM Primer: From Licenses to Security, Know What’s in Your Code, or Someone Else’s!](https://ossna2023.sched.com/event/1KtE8/an-sbom-primer-from-licenses-to-security-know-whats-in-your-code-or-someone-elses-jeff-shapiro-the-linux-foundation-gary-oneall-source-auditor) at the Open Source Summit North America 2023. 
+- The [`OSS-NA-2023`](./OSS-NA-2023/) directory contains the SPDX (v2.3)
+  JSON files used in the SBOM Primer presentation
+  - [*An SBOM Primer: From Licenses to Security, Know What’s in Your Code, or Someone Else’s!*](https://ossna2023.sched.com/event/1KtE8/an-sbom-primer-from-licenses-to-security-know-whats-in-your-code-or-someone-elses-jeff-shapiro-the-linux-foundation-gary-oneall-source-auditor)
+    at the Open Source Summit North America 2023<br />
+    [![Video - An SBOM Primer: From Licenses to Security, Know What’s in Your Code, or Someone Else’s!](https://img.youtube.com/vi/IbGc4nIn_ao/0.jpg)](https://youtu.be/IbGc4nIn_ao)


### PR DESCRIPTION
- OSSSumit2023 -> OSS-NA-2023
- form -> from
- Also add link to the presentation video