### PR TITLE
Make PR check fails when find invalid SPDX 2.x SBOM

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Validate SPDX 2.2 & SPDX 2.3 Documents
         run: |
+          set -e
           find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \) \
             -exec echo {} \; \
             -exec java -jar tools-java.jar Verify {} \;

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,7 +73,7 @@ jobs:
           FAILED_FILES=""
 
           for f in $(find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \)); do
-              echo "Checking $f..."
+              echo "$f"
               TOTAL_COUNT=$((TOTAL_COUNT + 1))
               java -jar tools-java.jar Verify "$f"
               if [ $? -eq 0 ]; then
@@ -92,7 +92,7 @@ jobs:
 
           if [ $FAILURE_COUNT -ne 0 ]; then
               echo ""
-              echo "Failed files:"
+              echo -n "Failed files:"
               echo -e "$FAILED_FILES"
           fi
 
@@ -103,7 +103,7 @@ jobs:
       - name: Validate SPDX 3.0 Documents
         run: |
           for f in $(find . -type f -path '*/spdx3.0/*.json'); do
-              echo "Checking $f..."
+              echo "$f"
               TOTAL_COUNT=$((TOTAL_COUNT + 1))
               spdx3-validate -j $f
               if [ $? -eq 0 ]; then
@@ -122,7 +122,7 @@ jobs:
 
           if [ $FAILURE_COUNT -ne 0 ]; then
               echo ""
-              echo "Failed files:"
+              echo -n "Failed files:"
               echo -e "$FAILED_FILES"
           fi
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Setup Java tools
         env:
-          VERSION: 2.0.0-RC2
+          TOOLS_JAVA_VER: 2.0.1
         run: |
           sudo apt install -y default-jdk
-          curl --location https://repo1.maven.org/maven2/org/spdx/tools-java/${VERSION}/tools-java-${VERSION}-jar-with-dependencies.jar --output tools-java.jar
+          curl --location https://repo1.maven.org/maven2/org/spdx/tools-java/${TOOLS_JAVA_VER}/tools-java-${TOOLS_JAVA_VER}-jar-with-dependencies.jar --output tools-java.jar
 
       - name: Setup Python tools
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,28 +63,52 @@ jobs:
           python3 -m pip install -U pip
           python3 -m pip install spdx3-validate
 
-      - name: Validate SPDX 2.2 & SPDX 2.3 Documents
+      - name: Validate SPDX documents
         run: |
           set +e
           EXIT_CODE=0
+          TOTAL_COUNT=0
+          PASSED_COUNT=0
+          FAILURE_COUNT=0
+          FAILED_FILES=""
 
           for f in $(find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \)); do
               echo "Checking $f..."
+              TOTAL_COUNT=$((TOTAL_COUNT + 1))
               java -jar tools-java.jar Verify "$f"
-              if [ $? -ne 0 ]; then
+              if [ $? -eq 0 ]; then
+                  PASSED_COUNT=$((PASSED_COUNT + 1))
+              else
+                  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+                  FAILED_FILES="$FAILED_FILES\n$f"
                   EXIT_CODE=1
               fi
           done
 
-          if [ $EXIT_CODE -ne 0 ]; then
-              echo ""
-              echo "One or more files failed validation."
-              exit $EXIT_CODE
-          fi
-
-      - name: Validate SPDX 3.0 Documents
-        run: |
           for f in $(find . -type f -path '*/spdx3.0/*.json'); do
               echo "Checking $f..."
+              TOTAL_COUNT=$((TOTAL_COUNT + 1))
               spdx3-validate -j $f
+              if [ $? -eq 0 ]; then
+                  PASSED_COUNT=$((PASSED_COUNT + 1))
+              else
+                  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+                  FAILED_FILES="$FAILED_FILES\n$f"
+                  EXIT_CODE=1
+              fi
           done
+
+          echo ""
+          echo "Files tested: $TOTAL_COUNT"
+          echo "Files passed: $PASSED_COUNT"
+          echo "Files failed: $FAILURE_COUNT"
+
+          if [ $FAILURE_COUNT -ne 0 ]; then
+              echo ""
+              echo "Failed files:"
+              echo -e "$FAILED_FILES"
+          fi
+
+          if [ $EXIT_CODE -ne 0 ]; then
+              exit $EXIT_CODE
+          fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,7 +63,8 @@ jobs:
           python3 -m pip install -U pip
           python3 -m pip install spdx3-validate
 
-      - name: Validate SPDX documents
+      - name: Validate SPDX 2.2 & SPDX 2.3 Documents
+        continue-on-error: true
         run: |
           set +e
           EXIT_CODE=0
@@ -85,6 +86,23 @@ jobs:
               fi
           done
 
+          echo ""
+          echo "Files tested: $TOTAL_COUNT"
+          echo "Files passed: $PASSED_COUNT"
+          echo "Files failed: $FAILURE_COUNT"
+
+          if [ $FAILURE_COUNT -ne 0 ]; then
+              echo ""
+              echo "Failed files:"
+              echo -e "$FAILED_FILES"
+          fi
+
+          if [ $EXIT_CODE -ne 0 ]; then
+              exit $EXIT_CODE
+          fi
+
+      - name: Validate SPDX 3.0 Documents
+        run: |
           for f in $(find . -type f -path '*/spdx3.0/*.json'); do
               echo "Checking $f..."
               TOTAL_COUNT=$((TOTAL_COUNT + 1))

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -93,7 +93,7 @@ jobs:
 
           for f in $(find . -type f -path '*/spdx3.0/*.json'); do
               echo "$f"
-              spdx3-validate -j $f
+              spdx3-validate --quiet --json $f
               if [ $? -ne 0 ]; then
                   FAIL_COUNT=$((FAIL_COUNT + 1))
                   FAIL_FILES="$FAIL_FILES\n$f"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,66 +66,44 @@ jobs:
       - name: Validate SPDX 2.2 & SPDX 2.3 Documents
         run: |
           set +e
-          EXIT_CODE=0
-          TOTAL_COUNT=0
-          PASSED_COUNT=0
-          FAILURE_COUNT=0
-          FAILED_FILES=""
+          FAIL_COUNT=0
+          FAIL_FILES=""
 
           for f in $(find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \)); do
               echo "$f"
-              TOTAL_COUNT=$((TOTAL_COUNT + 1))
               java -jar tools-java.jar Verify "$f"
-              if [ $? -eq 0 ]; then
-                  PASSED_COUNT=$((PASSED_COUNT + 1))
-              else
-                  FAILURE_COUNT=$((FAILURE_COUNT + 1))
-                  FAILED_FILES="$FAILED_FILES\n$f"
-                  EXIT_CODE=1
+              if [ $? -neq 0 ]; then
+                  FAIL_COUNT=$((FAIL_COUNT + 1))
+                  FAIL_FILES="$FAIL_FILES\n$f"
               fi
           done
 
-          echo ""
-          echo "Files tested: $TOTAL_COUNT"
-          echo "Files passed: $PASSED_COUNT"
-          echo "Files failed: $FAILURE_COUNT"
-
-          if [ $FAILURE_COUNT -ne 0 ]; then
+          if [ $FAIL_COUNT -ne 0 ]; then
               echo ""
-              echo -n "Failed files:"
-              echo -e "$FAILED_FILES"
-          fi
-
-          if [ $EXIT_CODE -ne 0 ]; then
-              exit $EXIT_CODE
+              echo "Files failed: $FAIL_COUNT"
+              echo -e "$FAIL_FILES"
+              exit 1
           fi
 
       - name: Validate SPDX 3.0 Documents
         run: |
+          set +e
+          FAIL_COUNT=0
+          FAIL_FILES=""
+
           for f in $(find . -type f -path '*/spdx3.0/*.json'); do
               echo "$f"
-              TOTAL_COUNT=$((TOTAL_COUNT + 1))
               spdx3-validate -j $f
-              if [ $? -eq 0 ]; then
-                  PASSED_COUNT=$((PASSED_COUNT + 1))
-              else
-                  FAILURE_COUNT=$((FAILURE_COUNT + 1))
-                  FAILED_FILES="$FAILED_FILES\n$f"
+              if [ $? -ne 0 ]; then
+                  FAIL_COUNT=$((FAIL_COUNT + 1))
+                  FAIL_FILES="$FAIL_FILES\n$f"
                   EXIT_CODE=1
               fi
           done
 
-          echo ""
-          echo "Files tested: $TOTAL_COUNT"
-          echo "Files passed: $PASSED_COUNT"
-          echo "Files failed: $FAILURE_COUNT"
-
-          if [ $FAILURE_COUNT -ne 0 ]; then
+          if [ $FAIL_COUNT -ne 0 ]; then
               echo ""
-              echo -n "Failed files:"
-              echo -e "$FAILED_FILES"
-          fi
-
-          if [ $EXIT_CODE -ne 0 ]; then
-              exit $EXIT_CODE
+              echo "Files failed: $FAIL_COUNT"
+              echo -e "$FAIL_FILES"
+              exit 1
           fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,7 +72,7 @@ jobs:
           for f in $(find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \)); do
               echo "$f"
               java -jar tools-java.jar Verify "$f"
-              if [ $? -neq 0 ]; then
+              if [ $? -ne 0 ]; then
                   FAIL_COUNT=$((FAIL_COUNT + 1))
                   FAIL_FILES="$FAIL_FILES\n$f"
               fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,15 +47,16 @@ jobs:
             exit 1
           fi
 
-      - name: Update apt
-        run: |
-          sudo apt update -y
+      - name: Setup Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  #v4.7.1
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
       - name: Setup Java tools
         env:
           TOOLS_JAVA_VER: 2.0.1
         run: |
-          sudo apt install -y default-jdk
           curl --location https://repo1.maven.org/maven2/org/spdx/tools-java/${TOOLS_JAVA_VER}/tools-java-${TOOLS_JAVA_VER}-jar-with-dependencies.jar --output tools-java.jar
 
       - name: Setup Python tools

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,10 +65,22 @@ jobs:
 
       - name: Validate SPDX 2.2 & SPDX 2.3 Documents
         run: |
-          set -e
-          find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \) \
-            -exec echo {} \; \
-            -exec java -jar tools-java.jar Verify {} \;
+          set +e
+          EXIT_CODE=0
+
+          for f in $(find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \)); do
+              echo "Checking $f..."
+              java -jar tools-java.jar Verify "$f"
+              if [ $? -ne 0 ]; then
+                  EXIT_CODE=1
+              fi
+          done
+
+          if [ $EXIT_CODE -ne 0 ]; then
+              echo ""
+              echo "One or more files failed validation."
+              exit $EXIT_CODE
+          fi
 
       - name: Validate SPDX 3.0 Documents
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout spdx-examples
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  #v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
 
       - name: Look for files with the wrong location
         run: |
@@ -52,11 +52,11 @@ jobs:
           sudo apt update -y
 
       - name: Setup Java tools
+        env:
+          VERSION: 2.0.0-RC2
         run: |
-          sudo apt install -y default-jdk maven
-          git clone https://github.com/spdx/tools-java.git && cd tools-java
-          export JAVA_HOME=$(readlink -f /usr/bin/javac | sed "s:/bin/javac::")
-          mvn clean install && cd ..
+          sudo apt install -y default-jdk
+          curl --location https://repo1.maven.org/maven2/org/spdx/tools-java/${VERSION}/tools-java-${VERSION}-jar-with-dependencies.jar --output tools-java.jar
 
       - name: Setup Python tools
         run: |
@@ -67,7 +67,7 @@ jobs:
         run: |
           find . \( -path '*/spdx2.2/*' -o -path '*/spdx2.3/*' \) \( -name *.spdx -o -name *.json \) \
             -exec echo {} \; \
-            -exec java -jar tools-java/target/tools-java-*-jar-with-dependencies.jar Verify {} \;
+            -exec java -jar tools-java.jar Verify {} \;
 
       - name: Validate SPDX 3.0 Documents
         run: |
@@ -75,4 +75,3 @@ jobs:
               echo "Checking $f..."
               spdx3-validate -j $f
           done
-

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,7 +64,6 @@ jobs:
           python3 -m pip install spdx3-validate
 
       - name: Validate SPDX 2.2 & SPDX 2.3 Documents
-        continue-on-error: true
         run: |
           set +e
           EXIT_CODE=0


### PR DESCRIPTION
This PR fix two issues in SPDX 2.x validation step in the PR check workflow:

1) **tools-java behavior is not stable:**
    - To fix that, this PR changes the workflow to use a released tools-java.jar, instead of build it from latest source.
    - Based on suggestion from @goneall in #114
2) **Check marked as "Passed" even some validations failed:**
    - To fix that, this PR changes the workflow to run `tools-java.jar Verify` outside `find -exec`, so the Verify exit code is not hidden and can be used to failed workflow.
    - The validation step will not failed immediately once find an invalid SBOM but will collect all invalid ones, report a summary at the end of the step, and exit with non-zero value to eventually failed the check.

This PR also add `--quiet` option to `spdx3-validate` to disable its spinner and make the run log more compact and easier to read.

--

Note that this PR currently failed the PR check because there are 3 SBOMs that don't pass the SBOM validation. These following issues have to be fixed before the check can get a pass:

- [ ] #117
- [x] #116
- [x] #102