### PR TITLE
Add suppliedBy and verifiedUsing (hash) for Dataset Example 01

### DIFF
--- a/dataset/example01/spdx3.0/example01.spdx3.json
+++ b/dataset/example01/spdx3.0/example01.spdx3.json
@@ -72,9 +72,22 @@
       "originatedBy": [
         "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
       ],
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
       "builtTime": "2023-12-16T11:22:38Z",
       "releaseTime": "2024-04-15T08:10:00Z",
       "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "32657f0d033fc07a7420be36a6af9083c6a63489"
+        },
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "434d75c84cf86456c16193dbc53beef31eb63f3387425882ddb2ef6acb9d472c"
+        }
+      ],
       "software_primaryPurpose": "data",
       "dataset_confidentialityLevel": "clear",
       "dataset_dataPreprocessing": [

--- a/dataset/example01/spdx3.0/example01.spdx3.json
+++ b/dataset/example01/spdx3.0/example01.spdx3.json
@@ -49,12 +49,12 @@
         "dataset"
       ],
       "rootElement": [
-        "https://spdx.org/spdxdocs/BOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
+        "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
       ]
     },
     {
-      "type": "Bom",
-      "spdxId": "https://spdx.org/spdxdocs/BOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
       "creationInfo": "_:creationinfo",
       "profileConformance": [
         "core",
@@ -62,6 +62,9 @@
       ],
       "rootElement": [
         "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b"
+      ],
+      "software_sbomType": [
+        "analyzed"
       ]
     },
     {
@@ -75,6 +78,8 @@
       "suppliedBy": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
       "builtTime": "2023-12-16T11:22:38Z",
       "releaseTime": "2024-04-15T08:10:00Z",
+      "software_packageVersion": "2024-04-15",
+      "software_copyrightText": "Copyright Our World in Data",
       "software_downloadLocation": "https://github.com/owid/co2-data/",
       "verifiedUsing": [
         {


### PR DESCRIPTION
- `suppliedBy`, `verifiedUsing`, and `software_packageVersion` will form the basis for NTIA Minimum Elements requirements ("Supplier Name", "Component Hash", and "Component Version String")
- This example will then be able to used for SBOM conformance checker test