### PR TITLE
AI: Add SPDX 3.1 (draft) for Example 02

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -3,7 +3,7 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC-BY-4.0
 ---
 
-# SPDX AI Profile Usage Examples
+# SPDX AI profile examples
 
 This repository includes demonstrations of [SPDX documents](https://spdx.dev)
 for various examples of AI applications and models.
@@ -13,15 +13,16 @@ for various examples of AI applications and models.
 Directories of the form `example##` are structured as follows:
 
 - `content/`: contains the example's content (data files, source code, etc.)
-- `spdx3.0/`: contains one or more SPDX documents for the example
+- `spdx3.0/`: contains SPDX 3.0 documents for the example
+- `spdx3.1/`: contains SPDX 3.1 documents for the example
 - `README.md`: more details about the particular example
 
 ## Examples
 
-|  # | Sources | Binaries | Data | SPDX | Comments |
-|----|---------|----------|------|------|----------|
-| [1](./example01/) | - | - | - | 1 document | Demonstrating `dependsOn`, `testedOn`, and `trainedOn` relationships |
-| [2](./example02/) | 4 Python files | 1 model file | 3 data files | 1 document | Demonstrating `generates`, `hasDataFile`, and `hasDocumentation` (lifecycle-scoped) relationships |
+| # | Sources | Binaries | Data | SPDX 3.0 | SPDX 3.1 | Focus |
+| - | ------- | -------- | ---- | -------- | -------- | ----- |
+| [01](./example01/) | - | - | - | 1 document | - | `dependsOn`, `testedOn`, `trainedOn` relationships |
+| [02](./example02/) | 4 Python files | 1 model file | 3 data files | 1 document | 1 document | `generates`, `hasDataFile`, `hasDocumentation`; `ai_energyConsumption`, `ai_hyperparameter`; **3.0→3.1**: `ai_autonomyType` → `isoAutomationLevel` |
 
 ## Implementing SBOM for AI systems
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -22,7 +22,7 @@ Directories of the form `example##` are structured as follows:
 | # | Sources | Binaries | Data | SPDX 3.0 | SPDX 3.1 | Focus |
 | - | ------- | -------- | ---- | -------- | -------- | ----- |
 | [01](./example01/) | - | - | - | 1 document | - | `dependsOn`, `testedOn`, `trainedOn` relationships |
-| [02](./example02/) | 4 Python files | 1 model file | 3 data files | 1 document | 1 document | `generates`, `hasDataFile`, `hasDocumentation`; `ai_energyConsumption`, `ai_hyperparameter`; **3.0→3.1**: `ai_autonomyType` → `isoAutomationLevel` |
+| [02](./example02/) | 4 Python files | 1 model file | 3 data files | 1 document | 1 document | `generates`, `hasDataFile`, `hasDocumentation` relationships; `/AI/energyConsumption`, `/AI/hyperparameter`; **3.0→3.1**: `/AI/autonomyType` → `/Core/isoAutomationLevel` |
 
 ## Implementing SBOM for AI systems
 

--- a/ai/example02/README.md
+++ b/ai/example02/README.md
@@ -23,7 +23,7 @@ and `dataset_datasetSize` is replaced by `software_artifactSize`.
 | Version | File |
 | --------- | ------ |
 | SPDX 3.0 | [spdx3.0/sbom.spdx3.json](./spdx3.0/sbom.spdx3.json) |
-| SPDX 3.1 (draft) | [spdx3.1/sbom.spdx3.json](./spdx3.1/sbom.spdx3.json) |
+| SPDX 3.1 (draft) | [spdx3.1/sbom.spdx3.json-draft](./spdx3.1/sbom.spdx3.json-draft) |
 
 [![A diagram showing relationships between elements in the Sentiment Demo package (Example 2).](./sbom-spdx3.png "A diagram showing relationships between elements in the Sentiment Demo package (Example 2).")](sbom-spdx3.png)
 

--- a/ai/example02/README.md
+++ b/ai/example02/README.md
@@ -10,15 +10,20 @@ SPDX-License-Identifier: CC-BY-4.0
 This example illustrates a software bill of materials (SBOM) for an AI
 application that employs machine learning to perform a text sentiment analysis.
 
-The SBOM ([spdx3.0/sbom.spdx.json](./spdx3.0/sbom.spdx.json)) demonstrates
-the structure between `AIPackage`, `DatasetPackage`, and their technical
-documentation through (lifecycle-scoped) relationship types such as
-`dependsOn`,
-`generates`,
-`hasDataFile`,
-`hasDocumentation`,
-`testedOn`, and
-`trainedOn`.
+The SBOM demonstrates the structure between `AIPackage`, `DatasetPackage`,
+and their technical documentation through lifecycle-scoped relationship types
+(`dependsOn`, `generates`, `hasDataFile`, `hasDocumentation`, `testedOn`, and
+`trainedOn`), and captures autonomy level and dataset size --
+two properties that migrate in SPDX 3.1:
+`ai_autonomyType` is replaced by `isoAutomationLevel: conditionalAutomation`,
+and `dataset_datasetSize` is replaced by `software_artifactSize`.
+
+## SPDX files
+
+| Version | File |
+| --------- | ------ |
+| SPDX 3.0 | [spdx3.0/sbom.spdx3.json](./spdx3.0/sbom.spdx3.json) |
+| SPDX 3.1 (draft) | [spdx3.1/sbom.spdx3.json](./spdx3.1/sbom.spdx3.json) |
 
 [![A diagram showing relationships between elements in the Sentiment Demo package (Example 2).](./sbom-spdx3.png "A diagram showing relationships between elements in the Sentiment Demo package (Example 2).")](sbom-spdx3.png)
 

--- a/ai/example02/spdx3.1/sbom.spdx3.json-draft
+++ b/ai/example02/spdx3.1/sbom.spdx3.json-draft
@@ -7,7 +7,7 @@
             "createdBy": [
                 "https://spdx.org/spdxdocs/SpdxDocument1-d1edd8cb-935e-46f2-bd5b-43f5f554a097#Person-AS"
             ],
-            "specVersion": "3.1.0",
+            "specVersion": "3.1",
             "type": "CreationInfo"
         },
         {

--- a/ai/example02/spdx3.1/sbom.spdx3.json-draft
+++ b/ai/example02/spdx3.1/sbom.spdx3.json-draft
@@ -19,7 +19,7 @@
                     "type": "ExternalIdentifier"
                 },
                 {
-                    "externalIdentifierType": "webpage",
+                    "externalIdentifierType": "other",
                     "identifier": "bact",
                     "identifierLocator": [
                         "https://github.com/bact/"

--- a/ai/example02/spdx3.1/sbom.spdx3.json-draft
+++ b/ai/example02/spdx3.1/sbom.spdx3.json-draft
@@ -1,13 +1,13 @@
 {
-    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@context": "https://spdx.org/rdf/3.1/spdx-context.jsonld",
     "@graph": [
         {
             "@id": "_:creationinfo",
-            "created": "2024-06-24T05:30:00Z",
+            "created": "2025-01-01T00:00:00Z",
             "createdBy": [
                 "https://spdx.org/spdxdocs/SpdxDocument1-d1edd8cb-935e-46f2-bd5b-43f5f554a097#Person-AS"
             ],
-            "specVersion": "3.0.1",
+            "specVersion": "3.1.0",
             "type": "CreationInfo"
         },
         {
@@ -222,7 +222,7 @@
         {
             "creationInfo": "_:creationinfo",
             "dataset_datasetAvailability": "directDownload",
-            "dataset_datasetSize": 11534336,
+            "software_artifactSize": 11534336,
             "dataset_datasetType": [
                 "text"
             ],
@@ -230,10 +230,10 @@
             "name": "Data after preprocessing",
             "software_downloadLocation": "https://github.com/bact/sentimentdemo/tree/main/data",
             "spdxId": "https://spdx.org/spdxdocs/SpdxDocument1-d1edd8cb-935e-46f2-bd5b-43f5f554a097#DatasetPackage1",
-            "type": "dataset_DatasetPackage"
+            "type": "dataset_DatasetPackage",
+            "comment": "SPDX 3.1 CHANGE: 'dataset_datasetSize: 11534336' (bytes, SPDX 3.0, deprecated) renamed to 'software_artifactSize: 11534336' (~11 MB) in SPDX 3.1. Compare with spdx3.0/sbom.spdx3.json."
         },
         {
-            "ai_autonomyType": "yes",
             "ai_domain": [
                 "sentiment analysis",
                 "natural language processing"
@@ -424,6 +424,7 @@
                 "supervised"
             ],
             "ai_useSensitivePersonalInformation": "no",
+            "isoAutomationLevel": "conditionalAutomation",
             "creationInfo": "_:creationinfo",
             "description": "A simple sentiment analysis application. Published solely as an artifact for the purpose of demonstrating a software bill of materials (SBOM). Not recommended for critical text classification tasks. The model is trained on a very small dataset, using fastText library. A. Joulin, E. Grave, P. Bojanowski, T. Mikolov, 2017, Bag of Tricks for Efficient Text Classification.",
             "name": "Sentiment Demo: A Simple AI Application and its AI BOM Example",
@@ -432,10 +433,11 @@
             "software_primaryPurpose": "model",
             "spdxId": "https://spdx.org/spdxdocs/SpdxDocument1-d1edd8cb-935e-46f2-bd5b-43f5f554a097#AIPackage1",
             "summary": "A sentiment analysis application, published to demonstrate a software bill of materials.",
-            "type": "ai_AIPackage"
+            "type": "ai_AIPackage",
+            "comment": "SPDX 3.1 CHANGE: 'ai_autonomyType: yes' (SPDX 3.0, PresenceType, deprecated) replaced by 'isoAutomationLevel: conditionalAutomation' — the model makes autonomous predictions when invoked, though the demo application context is non-critical. Compare with spdx3.0/sbom.spdx3.json."
         },
         {
-            "comment": "This meant to be a temporary workaround for the lack of the ListedLicense (from SPDX Licenses List) in SPDX 3.0 ontology. Once the ListedLicense instance for CC0-1.0 is available, this element should be removed. See: https://github.com/spdx/LicenseListPublisher/issues/183",
+            "comment": "In SPDX 3.1, ListedLicense instances from the SPDX License List are expected to be available directly. This workaround element may be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented.",
             "creationInfo": "_:creationinfo",
             "description": "Creative Commons Zero v1.0 Universal",
             "simplelicensing_licenseExpression": "CC0-1.0",

--- a/ai/example02/spdx3.1/sbom.spdx3.json-draft
+++ b/ai/example02/spdx3.1/sbom.spdx3.json-draft
@@ -19,7 +19,7 @@
                     "type": "ExternalIdentifier"
                 },
                 {
-                    "externalIdentifierType": "other",
+                    "externalIdentifierType": "webpage",
                     "identifier": "bact",
                     "identifierLocator": [
                         "https://github.com/bact/"
@@ -28,7 +28,7 @@
                     "type": "ExternalIdentifier"
                 },
                 {
-                    "externalIdentifierType": "other",
+                    "externalIdentifierType": "orchidid",
                     "identifier": "0000-0002-9698-1899",
                     "identifierLocator": [
                         "https://orcid.org/0000-0002-9698-1899"


### PR DESCRIPTION
Add SPDX 3.1 JSON for AI Example 02.

To demonstrate property deprecation in 3.1 (draft).

Use same spdxId in both SPDX 3.0 and SPDX 3.1 documents for easy comparison.