### PR TITLE
Fix SPDX 3.0 file deadlink

### DIFF
--- a/ai/example02/README.md
+++ b/ai/example02/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: CC-BY-4.0
 This example illustrates a software bill of materials (SBOM) for an AI
 application that employs machine learning to perform a text sentiment analysis.
 
-The SBOM ([spdx3.0/sbom.spdx.json](./spdx3.0/sbom.spdx.json)) demonstrates
+The SBOM ([spdx3.0/sbom.spdx3.json](./spdx3.0/sbom.spdx3.json)) demonstrates
 the structure between `AIPackage`, `DatasetPackage`, and their technical
 documentation through (lifecycle-scoped) relationship types such as
 `dependsOn`,

--- a/software/example11/README.md
+++ b/software/example11/README.md
@@ -34,7 +34,7 @@ The SBOM structure (outlinedgenerate with
 [bom](https://github.com/kubernetes-sigs/bom)) looks like this:
 
 ```shell
-$ bom document outline example11/spdx/sbom.spdx.json
+$ bom document outline example11/spdx2.3/sbom.spdx.json
 
  📂 SPDX Document SBOM-SPDX-2d85f548-12fa-46d5-87ce-5e78e5e111f4
   │ 


### PR DESCRIPTION
After renaming *.spdx.json -> *.spdx3.json (PR #133),
there is a dead link in AI Example 02 README. Fix it.