### PR TITLE
Dataset: Add SPDX 3.1 (draft) for Example 01

### DIFF
--- a/dataset/README.md
+++ b/dataset/README.md
@@ -21,4 +21,4 @@ Directories of the form `example##` are structured as follows:
 
 | # | Data | Sources | SPDX 3.0 | SPDX 3.1 | Focus |
 | - | ---- | ------- | -------- | -------- | ----- |
-| [01](./example01/) | 2 CSV files | - | 1 document | 1 document | Tabular CSV dataset; `dataset_datasetType: structured, timestamp`; **3.0→3.1**: `dataset_datasetSize` → `software_artifactSize`, `dataset_intendedUse` → Core `intendedUse` |
+| [01](./example01/) | 2 CSV files | - | 1 document | 1 document | Tabular CSV dataset; `/Dataset/datasetType: structured, timestamp`; **3.0→3.1**: `/Dataset/datasetSize` → `/Software/artifactSize`, `/Dataset/intendedUse` → `/Core/intendedUse` |

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -3,7 +3,7 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC-BY-4.0
 ---
 
-# SPDX Dataset Profile Examples
+# SPDX Dataset profile examples
 
 This repository includes demonstrations of [SPDX documents](https://spdx.dev)
 for a Dataset Profile.
@@ -12,13 +12,13 @@ for a Dataset Profile.
 
 Directories of the form `example##` are structured as follows:
 
-- `content/`: contains the example's content (data files, related source code,
-  etc.)
-- `spdx3.0/`: contains one or more SPDX documents for the example
+- `content/`: contains the example's content (data files, source code, etc.)
+- `spdx3.0/`: contains SPDX 3.0 documents for the example
+- `spdx3.1/`: contains SPDX 3.1 documents for the example
 - `README.md`: more details about the particular example
 
 ## Examples
 
-| ## | Data | Sources | SPDX | Comments |
-|----|------|---------|------|----------|
-| [01](./example01/) | 2 CSV files | - | 1 document | An example of a simple dataset in tabular format. |
+| # | Data | Sources | SPDX 3.0 | SPDX 3.1 | Focus |
+| - | ---- | ------- | -------- | -------- | ----- |
+| [01](./example01/) | 2 CSV files | - | 1 document | 1 document | Tabular CSV dataset; `dataset_datasetType: structured, timestamp`; **3.0→3.1**: `dataset_datasetSize` → `software_artifactSize`, `dataset_intendedUse` → Core `intendedUse` |

--- a/dataset/example01/README.md
+++ b/dataset/example01/README.md
@@ -36,3 +36,14 @@ class diagram illustrates Example 01.  Long string values are truncated and the
 spdxIds are shortened (by removing the UUID suffix), for brevity.
 
 [![A diagram of a bill of materials of Dataset Example 01](./spdx3.0/example01.png "A diagram of a bill of materials of Dataset Example 01")](./spdx3.0/example01.png)
+
+The SBOM uses `dataset_datasetSize` (~200 KB) and `dataset_intendedUse`, both
+of which are deprecated in SPDX 3.1 in favour of `software_artifactSize` and
+Core `intendedUse` respectively.
+
+## SPDX files
+
+| Version | File |
+| --------- | ------ |
+| SPDX 3.0 | [spdx3.0/example01.spdx3.json](./spdx3.0/example01.spdx3.json) |
+| SPDX 3.1 (draft) | [spdx3.1/example01.spdx3.json-draft](./spdx3.1/example01.spdx3.json-draft) |

--- a/dataset/example01/README.md
+++ b/dataset/example01/README.md
@@ -3,7 +3,7 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC-BY-4.0
 ---
 
-# Example 01
+# Dataset example 1 - Gas emissions dataset
 
 ## Description
 
@@ -30,20 +30,14 @@ Greenhouse Gas Emissions dataset. It is available in full, under Creative
 Commons Attribution 4.0 International License, at
 <https://github.com/owid/co2-data/>.
 
-This simplified
-[Unified Modeling Language (UML)](https://en.wikipedia.org/wiki/Unified_Modeling_Language)
-class diagram illustrates Example 01.  Long string values are truncated and the
-spdxIds are shortened (by removing the UUID suffix), for brevity.
-
-[![A diagram of a bill of materials of Dataset Example 01](./spdx3.0/example01.png "A diagram of a bill of materials of Dataset Example 01")](./spdx3.0/example01.png)
-
-The SBOM uses `dataset_datasetSize` (~200 KB) and `dataset_intendedUse`, both
-of which are deprecated in SPDX 3.1 in favour of `software_artifactSize` and
-Core `intendedUse` respectively.
+The SBOM uses `/Dataset/datasetSize` (~200 KB) and `/Dataset/intendedUse`, both
+of which are deprecated in SPDX 3.1 in favour of `/Software/artifactSize` and `/Core/intendedUse` respectively.
 
 ## SPDX files
 
 | Version | File |
-| --------- | ------ |
+| ------- | ---- |
 | SPDX 3.0 | [spdx3.0/example01.spdx3.json](./spdx3.0/example01.spdx3.json) |
 | SPDX 3.1 (draft) | [spdx3.1/example01.spdx3.json-draft](./spdx3.1/example01.spdx3.json-draft) |
+
+[![A diagram of Dataset profile example 01 - Simple tabular dataset.](./example01.spdx3.png "A diagram of Dataset profile example 01 - Simple tabular dataset.")](./example01.spdx3.png)

--- a/dataset/example01/spdx3.1/example01.spdx3.json-draft
+++ b/dataset/example01/spdx3.1/example01.spdx3.json-draft
@@ -4,7 +4,7 @@
     {
       "type": "CreationInfo",
       "@id": "_:creationinfo",
-      "specVersion": "3.1.0",
+      "specVersion": "3.1",
       "createdBy": [
         "https://spdx.org/spdxdocs/dataset-example01-b1b2c3d4-e5f6-7890-abcd-000000001002#Person1"
       ],

--- a/dataset/example01/spdx3.1/example01.spdx3.json-draft
+++ b/dataset/example01/spdx3.1/example01.spdx3.json-draft
@@ -1,14 +1,14 @@
 {
-  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@context": "https://spdx.org/rdf/3.1/spdx-context.jsonld",
   "@graph": [
     {
       "type": "CreationInfo",
       "@id": "_:creationinfo",
-      "specVersion": "3.0.1",
+      "specVersion": "3.1.0",
       "createdBy": [
         "https://spdx.org/spdxdocs/dataset-example01-b1b2c3d4-e5f6-7890-abcd-000000001002#Person1"
       ],
-      "created": "2024-05-31T00:00:00Z"
+      "created": "2025-01-01T00:00:00Z"
     },
     {
       "type": "Person",
@@ -81,6 +81,7 @@
       "software_packageVersion": "2024-04-15",
       "software_copyrightText": "Copyright Our World in Data",
       "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "software_artifactSize": 204800,
       "verifiedUsing": [
         {
           "type": "Hash",
@@ -94,6 +95,7 @@
         }
       ],
       "software_primaryPurpose": "data",
+      "intendedUse": "To make the data about greenhouse gas emissions accessible.",
       "dataset_confidentialityLevel": "clear",
       "dataset_dataPreprocessing": [
         "The dataset is built upon a number of datasets and processing steps.",
@@ -101,18 +103,16 @@
       ],
       "dataset_datasetAvailability": "directDownload",
       "dataset_dataCollectionProcess": "The data is collected from various sources, including international organizations and research institutions.",
-      "dataset_datasetSize": 204800,
       "dataset_datasetType": [
         "structured",
         "timestamp"
       ],
       "dataset_datasetUpdateMechanism": "Publish updated data as it becomes available. Most are on an annual basis.",
       "dataset_hasSensitivePersonalInformation": "no",
-      "dataset_intendedUse": "To make the data about greenhouse gas emissions accessible.",
       "dataset_knownBias": [
         "Data in some geographical areas are more completed than the others."
       ],
-      "comment": "This is a small excerpt of the full dataset."
+      "comment": "This is a small excerpt of the full dataset. SPDX 3.1 CHANGES: (1) 'dataset_datasetSize: 204800' (bytes, SPDX 3.0, deprecated) renamed to 'software_artifactSize: 204800' (~200 KB) in SPDX 3.1. (2) 'dataset_intendedUse' (SPDX 3.0, deprecated) replaced by Core-level 'intendedUse'. Compare with spdx3.0/example01.spdx3.json."
     },
     {
       "type": "software_File",
@@ -189,8 +189,7 @@
       "spdxId": "https://spdx.org/licenses/CC-BY-4.0",
       "creationInfo": "_:creationinfo",
       "simplelicensing_licenseExpression": "CC-BY-4.0",
-      "simplelicensing_licenseListVersion": "3.25.0",
-      "comment": "Added as a workaround for the lack of https://spdx.org/licenses/CC-BY-4.0 as a valid ListedLicense in SPDX 3.0.1 RDF. This will be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented."
+      "simplelicensing_licenseListVersion": "3.25.0"
     }
   ]
 }


### PR DESCRIPTION
Add SPDX 3.1 JSON for Dataset Example 01.

To demonstrate property deprecation in 3.1 (draft).

Use same spdxId in both SPDX 3.0 and SPDX 3.1 documents for easy comparison.